### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,10 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  gem-hash:
-    description: "base64-encoded sha256 hashes of distribution files"
-    value: ${{ steps.gem-hash.outputs.gem-hash }}
 
 runs:
   using: composite
@@ -15,12 +11,6 @@ runs:
     - name: Build gemspec
       shell: bash
       run: gem build launchdarkly-server-sdk-otel.gemspec
-
-    - name: Hash gem for provenance
-      id: gem-hash
-      shell: bash
-      run: |
-        echo "gem-hash=$(sha256sum launchdarkly-server-sdk-otel-*.gem | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Publish Library
       shell: bash

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write # Needed for actions/attest
     outputs:
       gem-hash: ${{ steps.publish.outputs.gem-hash}}
     steps:
@@ -37,13 +38,15 @@ jobs:
         with:
           dry_run: ${{ inputs.dry_run }}
 
-  release-provenance:
-    needs: [ 'build-publish' ]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.build-publish.outputs.gem-hash }}"
-      upload-assets: ${{ !inputs.dry_run }}
+      - name: Generate checksums file
+        if: ${{ !inputs.dry_run }}
+        env:
+          HASHES: ${{ steps.publish.outputs.gem-hash }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,6 +6,15 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
+      tag:
+        description: 'Tag of an existing draft release to upload artifacts to.'
+        type: string
+        required: false
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build-publish:
@@ -50,3 +59,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['build-publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -10,11 +10,6 @@ on:
         description: 'Tag of an existing draft release to upload artifacts to.'
         type: string
         required: false
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
 jobs:
   build-publish:
@@ -59,19 +54,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['build-publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -19,8 +19,6 @@ jobs:
       id-token: write
       contents: read
       attestations: write # Needed for actions/attest
-    outputs:
-      gem-hash: ${{ steps.publish.outputs.gem-hash}}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,15 +40,8 @@ jobs:
         with:
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ !inputs.dry_run }}
-        env:
-          HASHES: ${{ steps.publish.outputs.gem-hash }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ !inputs.dry_run }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'launchdarkly-server-sdk-otel-*.gem'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -37,7 +37,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ !inputs.dry_run }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'launchdarkly-server-sdk-otel-*.gem'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,10 +6,6 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag of an existing draft release to upload artifacts to.'
-        type: string
-        required: false
 
 jobs:
   build-publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,6 @@ jobs:
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
       attestations: write # Needed for actions/attest
-    outputs:
-      release-created: ${{ steps.release.outputs.release_created }}
-      upload-tag-name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write # Needed for actions/attest
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
       upload-tag-name: ${{ steps.release.outputs.tag_name }}
@@ -24,6 +25,22 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -51,15 +68,31 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-  release-provenance:
-    needs: [ 'release-package' ]
+      - name: Generate checksums file
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          HASHES: ${{ steps.publish.outputs.gem-hash }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['release-package']
     if: ${{ needs.release-package.outputs.release-created == 'true' }}
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.release-package.outputs.gem-hash }}"
-      upload-assets: true
-      upload-tag-name: ${{ needs.release-package.outputs.upload-tag-name }}
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,22 +26,6 @@ jobs:
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
-      - name: Create release tag
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
-        env:
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         name: 'Get rubygems API key'
@@ -80,19 +64,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['release-package']
-    if: ${{ needs.release-package.outputs.release-created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,6 @@ jobs:
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
       upload-tag-name: ${{ steps.release.outputs.tag_name }}
-      gem-hash: ${{ steps.publish.outputs.gem-hash}}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
@@ -52,15 +51,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Generate checksums file
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
-        env:
-          HASHES: ${{ steps.publish.outputs.gem-hash }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'launchdarkly-server-sdk-otel-*.gem'

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,14 +1,14 @@
-## Verifying SDK build provenance with the SLSA framework
+## Verifying SDK build provenance with GitHub artifact attestations
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
-As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `multiple-provenance.intoto.jsonl`.
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
 
-To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying SDK packages is included below:
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
 
 <!-- x-release-please-start-version -->
 ```
-# Set the version of the SDK to verify
+# Set the version of the library to verify
 VERSION=1.1.1
 ```
 <!-- x-release-please-end -->
@@ -17,27 +17,33 @@ VERSION=1.1.1
 # Download gem
 $ gem fetch launchdarkly-server-sdk-otel -v $VERSION
 
-# Download provenance from Github release
-$ curl --location -O \
-  https://github.com/launchdarkly/ruby-server-sdk-otel/releases/download/${VERSION}/launchdarkly-server-sdk-otel-${VERSION}.gem.intoto.jsonl
-
-# Run slsa-verifier to verify provenance against package artifacts 
-$ slsa-verifier verify-artifact \
---provenance-path launchdarkly-server-sdk-otel-${VERSION}.gem.intoto.jsonl \
---source-uri github.com/launchdarkly/ruby-server-sdk-otel \
-launchdarkly-server-sdk-otel-${VERSION}.gem
+# Verify provenance using the GitHub CLI
+$ gh attestation verify launchdarkly-server-sdk-otel-${VERSION}.gem --owner launchdarkly
 ```
 
 Below is a sample of expected output.
 
 ```
-Verified signature against tlog entry index 83653185 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a7df0bbf87a7d5fcaafa551a2101d9f993d251a56a918bb113e81d2c575dc7e25
-Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.10.0" at commit 14c48a68c45871c27409591969e7f4c0ebdcdf62
-Verifying artifact launchdarkly-server-sdk-otel-1.0.0.gem: PASSED
+Loaded digest sha256:... for file://launchdarkly-server-sdk-otel-1.1.1.gem
+Loaded 1 attestation from GitHub API
 
-PASSED: Verified SLSA provenance
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/ruby-server-sdk-otel
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/ruby-server-sdk-otel
+  - Signer workflow: .github/workflows/release-please.yml
 ```
 
-Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
 
-**Note:** These instructions do not apply when building our libraries from source. 
+**Note:** These instructions do not apply when building our libraries from source.  

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with the SLSA framework
+Verifying library build provenance with GitHub artifact attestations
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with GitHub artifact attestations
+Verifying library build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "versioning": "default",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
+      "draft": true,
       "extra-files": ["PROVENANCE.md", "lib/ldclient-otel/version.rb"]
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "versioning": "default",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "PROVENANCE.md",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "draft": true,
-      "extra-files": ["PROVENANCE.md", "lib/ldclient-otel/version.rb"]
+      "force-tag-creation": true,
+      "extra-files": [
+        "PROVENANCE.md",
+        "lib/ldclient-otel/version.rb"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "versioning": "default",
       "include-component-in-tag": false,
       "include-v-in-tag": false,
-      "force-tag-creation": true,
       "extra-files": [
         "PROVENANCE.md",
         "lib/ldclient-otel/version.rb"


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only changes, no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Reference implementation: `launchdarkly/ld-relay`.

**Describe the solution you've provided**

Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API, not as release assets. This PR makes the following changes:

1. **Replace SLSA generator with `actions/attest@v4`** (`release-please.yml`, `manual-publish.yml`): The separate `release-provenance` job using `slsa-framework/slsa-github-generator` (which uploaded `.intoto.jsonl` files as release assets via `upload-assets: true`) is removed in both workflows. Attestation is now done inline via `actions/attest@v4` with `subject-path`, referencing the built gem file directly (`launchdarkly-server-sdk-otel-*.gem`). The `attestations: write` permission is added to the build jobs.

2. **Remove base64 hash round-trip** (`.github/actions/publish/action.yml`): The `gem-hash` output and "Hash gem for provenance" step are removed from the composite action. The old SLSA generator required `base64-subjects`, which meant the composite action had to `sha256sum | base64 -w0` and the workflow had to decode it back. With `subject-path`, `actions/attest@v4` reads the file directly from disk — no hashing or encoding needed.

3. **Remove orphaned job outputs** (`release-please.yml`): The `release-created`, `upload-tag-name`, and `gem-hash` outputs on the `release-package` job were only consumed by the now-removed `release-provenance` job. They have been cleaned up.

4. **Update provenance documentation** (`PROVENANCE.md`): Replaced SLSA verifier instructions with `gh attestation verify` instructions and updated sample output to reflect GitHub artifact attestations. The `x-release-please-start-version` marker is preserved so release-please keeps the version in sync.

5. **Cosmetic**: The `extra-files` array in `release-please-config.json` was reformatted from inline to multi-line.

**Key points for review:**
- Verify that the glob `launchdarkly-server-sdk-otel-*.gem` matches the gem built by `gem build launchdarkly-server-sdk-otel.gemspec` in the composite action (the gem is built in the workspace root, and the attest step runs in the same job).
- `release-please.yml` gates the attest step on `releases_created` (plural) — this is the correct aggregate output for manifest mode. The manual publish workflow gates on `format('{0}', inputs.dry_run) == 'false'` to handle both boolean and string input types.
- No way to test `actions/attest` on a feature branch since it requires a real release context. A dry-run dispatch can confirm the guard prevents attestation from running.

### Updates since last revision

- Switched attestation input from `subject-checksums: checksums.txt` to `subject-path: 'launchdarkly-server-sdk-otel-*.gem'`, eliminating the base64 encode/decode round-trip entirely.
- Removed `gem-hash` output and "Hash gem for provenance" step from `.github/actions/publish/action.yml`.
- Removed "Generate checksums file" step from workflows (no longer needed).
- Removed unused `tag` input from `manual-publish.yml` (was added for consistency but never referenced by any step).
- Removed orphaned `release-created` and `upload-tag-name` outputs from `release-please.yml` (their sole consumer, the `release-provenance` job, was removed).
- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release`) that was briefly added. This pattern is only needed for repos that upload artifacts to releases (which require draft releases). Since this repo is attestation-only, the standard single-pass release-please is correct.

**Describe alternatives you've considered**

- An earlier revision used `subject-checksums` with a checksums file generated by decoding base64-encoded hashes from the composite action. `subject-path` is simpler since the gem file is already on disk in the same job.
- An earlier revision used draft releases with a `publish-release` job to un-draft after completion. This was simplified since this repo only uses attestation (not artifact uploads), making draft releases unnecessary.

**Additional context**

No build/publish logic was changed — only the provenance mechanism (SLSA → actions/attest with `subject-path`) and release-please config formatting were modified. The `format('{0}', inputs.dry_run)` pattern stringifies the input regardless of source type, ensuring `== 'false'` works for both `workflow_call` (boolean) and `workflow_dispatch` (string) triggers.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84