### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,50 +6,81 @@ on:
       - main
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        id: release
+        with:
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          skip-github-release: true
+
   release-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
-      pull-requests: write
       attestations: write # Needed for actions/attest
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
-        id: release
-
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         name: 'Get rubygems API key'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/rubygems/api_key = GEM_HOST_API_KEY'
 
       - uses: ./.github/actions/ci
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           ruby-version: 3.0
 
       - uses: ./.github/actions/build-docs
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/publish
         id: publish
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           dry_run: false
 
       - uses: ./.github/actions/publish-docs
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
           subject-path: 'launchdarkly-server-sdk-otel-*.gem'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
@@ -48,7 +48,7 @@ jobs:
 
   release-package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

_N/A — CI-only workflow change, no application code or tests affected._

**Related issues**

Follows the pattern established in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622) to support GitHub's immutable releases.

**Describe the solution you've provided**

Splits the single `release-package` job into two jobs to decouple release creation from PR management:

1. **`release-please` job** — Runs release-please in two passes:
   - *Pass 1* (`skip-github-pull-request: true`): Creates a GitHub release if one is pending. If created, checks out the repo and pushes the tag (with an idempotent guard).
   - *Pass 2* (`skip-github-release: true`): Only runs if no release was created; handles release PR creation/updates.

2. **`release-package` job** — Now depends on `release-please` and is gated on `releases_created == 'true'`. Individual step-level `if` guards are removed since the job itself only runs on release.

This two-pass approach ensures the tag exists before release-please evaluates whether a new release PR is needed, preventing duplicate PRs.

**Describe alternatives you've considered**

A single-pass approach where release-please handles both releases and PRs simultaneously — this is the current behavior and causes issues with GitHub's immutable releases because the tag may not exist when release-please checks PR state.

**Additional context**

Things for reviewers to verify:

- The `release-please` job outputs `releases_created` (plural) for the downstream job gate, but the inline tag-creation conditions use `release_created` (singular). Both are valid release-please outputs; for this single-package repo they should be equivalent, but confirm this is intentional.
- The `release-package` job no longer has `pull-requests: write` permission (previously needed because release-please ran in that job). Confirm no downstream composite action requires it.
- The action pin SHA `16a9c90856f42705d54a6fda1823352bdc62cf38` is unchanged; the version comment was updated from `# v4` to `# v4.4.0`.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation workflow by adding manual tag creation and new job gating, which could impact whether releases/tags/PRs are created correctly. No application code changes, but misconfiguration could break publishing.
> 
> **Overview**
> **Splits the GitHub Actions release flow into two jobs** so release creation/tagging is separated from release PR management.
> 
> A new `release-please` job runs `release-please` in two passes: first to create a GitHub release (skipping PRs), then—only if no release was created—to manage release PRs (skipping releases). When a release is created, the workflow now checks out the repo and **creates/pushes the release tag idempotently**.
> 
> `release-package` now depends on `release-please` and only runs when `release_created` is true, removing the prior step-level `if` guards and dropping `pull-requests: write` permissions from the packaging job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f144b07b359bd294a1b620433e77beb041b2cf77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->