### PR TITLE
fix: Loosen launchdarkly-server-sdk constraint to ~> 8.4

### DIFF
--- a/launchdarkly-server-sdk-otel.gemspec
+++ b/launchdarkly-server-sdk-otel.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.4.0"
+  spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.4"
   spec.add_runtime_dependency "opentelemetry-sdk", "~> 1.0", ">= 1.4.0"
 
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Fixes SDK-2454.

## Summary
- Changes the `launchdarkly-server-sdk` runtime dependency from `~> 8.4.0` to `~> 8.4`
- `~> 8.4.0` incorrectly limited the constraint to < 8.5.0, blocking users on newer minor versions
- `~> 8.4` allows any 8.x minor version >= 8.4.0, which is the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line gemspec dependency constraint change with no runtime code or security impact.
> 
> **Overview**
> Updates the **launchdarkly-server-sdk-otel** gemspec so the runtime dependency on `launchdarkly-server-sdk` uses **`~> 8.4`** instead of **`~> 8.4.0`**.
> 
> With the old form, Bundler treated the upper bound as **&lt; 8.5.0**, so apps could not resolve newer **8.x** SDK releases even when they stayed on major version 8. The new constraint matches the intended range: **≥ 8.4.0** and **&lt; 9.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ea028720582de738b807dd3438c711e4c805de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->